### PR TITLE
Small fixes to make install.sql run without errors and warnings on newer MariaDB versions 

### DIFF
--- a/bulls_cows/install.sql
+++ b/bulls_cows/install.sql
@@ -18,9 +18,7 @@
 \W
 
 
-INSTALL SONAME 'ha_sequence';
-
-
+DROP DATABASE IF EXISTS bulls_cows;
 CREATE DATABASE bulls_cows
         DEFAULT CHARACTER SET utf8;
 USE bulls_cows;
@@ -182,4 +180,3 @@ BEGIN
 END ||
 
 DELIMITER ;
-

--- a/hangman/install.sql
+++ b/hangman/install.sql
@@ -18,7 +18,8 @@
 */
 
 
-CREATE DATABASE IF NOT EXISTS `hangman`
+DROP DATABASE IF EXISTS `hangman`;
+CREATE DATABASE `hangman`
         DEFAULT CHARACTER SET 'utf8';
 USE hangman;
 
@@ -26,7 +27,7 @@ USE hangman;
 DELIMITER ||
 
 
-DROP PROCEDURE IF EXISTS install_game ||
+DROP PROCEDURE IF EXISTS install_game;
 CREATE PROCEDURE install_game()
         MODIFIES SQL DATA
         COMMENT 'Installs Hangman'
@@ -209,7 +210,7 @@ BEGIN
         SET @cur_ch = '';
         SET @found_chars = '';
         
-        SELECT `word` FROM `hangman`.`word` ORDER BY RAND() LIMIT 1 INTO @word;
+        SELECT `word` INTO @word FROM `hangman`.`word` ORDER BY RAND() LIMIT 1;
         SET @hidden = get_hidden_word(@word);
         
         SELECT CONCAT(
@@ -316,4 +317,3 @@ END ||
 DELIMITER ;
 
 COMMIT;
-


### PR DESCRIPTION
I tested this on MariaDB 10.4 and got a few errors and warnings:

$ mariadb < install.sql 
Note (Code 1008): Can't drop database 'anagram'; database doesn't exist
ERROR 1126 (HY000) at line 21 in file: './bulls_cows/install.sql': Can't open shared library '/usr/lib64/mysql/plugin/ha_sequence.so' (errno: 2, cannot open shared object file: No such file or directory)
Note (Code 1305): PROCEDURE hangman.install_game does not exist
Warning (Code 1287): '<select expression> INTO <destination>;' is deprecated and will be removed in a future release. Please use 'SELECT <select list> INTO <destination> FROM...' instead

I suspect the ha_sequence error is because the sequence engine is now (since 10.1) installed by default.

My commits attempt to remove these errors/warnings.
